### PR TITLE
[#20] EntityNotFoundException 설정

### DIFF
--- a/src/main/java/com/hobak/happinessql/global/exception/EntityNotFoundException.java
+++ b/src/main/java/com/hobak/happinessql/global/exception/EntityNotFoundException.java
@@ -1,0 +1,10 @@
+package com.hobak.happinessql.global.exception;
+
+import com.hobak.happinessql.global.response.Code;
+
+public class EntityNotFoundException extends GeneralException{
+
+    public EntityNotFoundException(String message) {
+        super(Code.ENTITY_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/hobak/happinessql/global/response/Code.java
+++ b/src/main/java/com/hobak/happinessql/global/response/Code.java
@@ -19,17 +19,23 @@ public enum Code {
     // ex) 이상은이 닉네임 중복 에러코드를 만든다면
     // USER_NICKNAME_DUPLICATED(11010, HttpStatus.BAD_REQUEST, "User nickname duplicated"),
 
+    // Common
     OK(0, HttpStatus.OK, "Ok"),
 
     BAD_REQUEST(10000, HttpStatus.BAD_REQUEST, "Bad request"),
     VALIDATION_ERROR(10001, HttpStatus.BAD_REQUEST, "Validation error"),
-    NOT_FOUND(10002, HttpStatus.NOT_FOUND, "Requested resource is not found"),
+    ENTITY_NOT_FOUND(404, HttpStatus.NOT_FOUND, " Entity Not Found"),
+    METHOD_NOT_ALLOWED(10004, HttpStatus.METHOD_NOT_ALLOWED, "대상 리소스가 이 메서드를 지원하지 않습니다."),
 
-    INTERNAL_ERROR(20000, HttpStatus.INTERNAL_SERVER_ERROR, "Internal error"),
-    DATA_ACCESS_ERROR(20001, HttpStatus.INTERNAL_SERVER_ERROR, "Data access error"),
+    INTERNAL_ERROR(10005, HttpStatus.INTERNAL_SERVER_ERROR, "Internal error"),
+    DATA_ACCESS_ERROR(10006, HttpStatus.INTERNAL_SERVER_ERROR, "Data access error"),
 
-    UNAUTHORIZED(40000, HttpStatus.UNAUTHORIZED, "User unauthorized");
+    // User
+    UNAUTHORIZED(30000, HttpStatus.UNAUTHORIZED, "User unauthorized"),
 
+
+    // Record
+    RECORD_NOT_FOUND(40000, HttpStatus.NOT_FOUND, "존재하지 않는 행복 기록입니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

GeneralException을 상속하는 EntityNotFoundException을 생성했습니다.
- ErorrCode 설정
- EntityNotFoundException을 상속하는 Record 도메인의 RecordNotFoundException을 다음과 같이 생성할 수 있습니다.
```java
public class RecordNotFoundException extends EntityNotFoundException {
    public RecordNotFoundException(String target) {
        super(target + "is not found");
    }
}
```


해당 클래스를 상속하여 커스텀 Not Found 에러 헨들러를 설정할 수 있습니다.


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
