### PR TITLE
[#39] 활동 리스트 조회 API 수정

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
@@ -17,11 +17,8 @@ public class ActivityController {
     private final ActivityListService activityListService;
 
     @GetMapping
-    public DataResponseDto<Object> getActivities(
-            @RequestParam(value = "lastCategoryId", defaultValue = "0") Long lastCategoryId,
-            @RequestParam(value = "size", defaultValue = "10") int size,
-            @RequestParam(value = "userId") Long userId) {
-        ActivityListResponseDto response = activityListService.getActivities(lastCategoryId, size, userId);
-        return DataResponseDto.of(response, "활동 목록을 성공적으로 조회했습니다.");
+    public DataResponseDto<ActivityListResponseDto> getActivitiesByUserId(@RequestParam Long userId) {
+        ActivityListResponseDto response = activityListService.getActivitiesByUserId(userId);
+        return DataResponseDto.of(response, "사용자의 모든 카테고리별 활동을 성공적으로 조회했습니다.");
     }
 }

--- a/src/main/java/com/hobak/happinessql/domain/activity/repository/CategoryRepository.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/repository/CategoryRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CategoryRepository extends JpaRepository<Category, Long>{
     Page<Category> findByCategoryIdGreaterThanOrderByCategoryIdAsc(Long lastCategoryId, Pageable pageable);
+    Optional<Category> findByName(String name);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #39

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- 활동 리스트 조회 API를 쿼리파라미터로 userId를 받아 해당 사용자의 모든 활동을 조회하는 것으로 수정했습니다. 
- /api/activities?userId=1로 요청 시 다음과 같은 응답을 받을 수 있습니다.
```json
{
  "success": true,
  "code": 0,
  "message": "사용자의 모든 카테고리별 활동을 성공적으로 조회했습니다.",
  "data": {
    "categories": [
      {
        "id": 1,
        "name": "운동",
        "activities": [
          {
            "id": 1,
            "name": "수영",
            "emoji": "🏊️"
          },
          {
            "id": 2,
            "name": "축구",
            "emoji": "⚽️"
          }
        ]
      },
      {
        "id": 2,
        "name": "음식",
        "activities": [
          {
            "id": 3,
            "name": "밥먹기",
            "emoji": "🍽️"
          }
        ]
      },
      {
        "id": 3,
        "name": "취미",
        "activities": [
          {
            "id": 4,
            "name": "피크닉",
            "emoji": "🧺"
          }
        ]
      }
    ]
  }
}
``` 

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 기타 카테고리 추가 후, 사용자별 기타 카테고리 조회 부분을 수정할 예정입니다.

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
