### PR TITLE
[#38] 활동 추가 API 구현

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
@@ -1,13 +1,13 @@
 package com.hobak.happinessql.domain.activity.api;
 
+import com.hobak.happinessql.domain.activity.application.ActivityCreateService;
+import com.hobak.happinessql.domain.activity.dto.ActivityCreateRequestDto;
+import com.hobak.happinessql.domain.activity.dto.ActivityCreateResponseDto;
 import com.hobak.happinessql.domain.activity.dto.ActivityListResponseDto;
 import com.hobak.happinessql.domain.activity.application.ActivityListService;
 import com.hobak.happinessql.global.response.DataResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/activities")
@@ -15,10 +15,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class ActivityController {
 
     private final ActivityListService activityListService;
+    private final ActivityCreateService activityCreateService;
 
     @GetMapping
     public DataResponseDto<ActivityListResponseDto> getActivitiesByUserId(@RequestParam Long userId) {
         ActivityListResponseDto response = activityListService.getActivitiesByUserId(userId);
         return DataResponseDto.of(response, "사용자의 모든 카테고리별 활동을 성공적으로 조회했습니다.");
+    }
+    @PostMapping
+    public DataResponseDto<ActivityCreateResponseDto> createActivity(@RequestBody ActivityCreateRequestDto request, @RequestParam Long userId){
+        ActivityCreateResponseDto response = activityCreateService.createActivity(request,userId);
+        return DataResponseDto.of(response,"활동을 성공적으로 추가했습니다.");
     }
 }

--- a/src/main/java/com/hobak/happinessql/domain/activity/application/ActivityCreateService.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/application/ActivityCreateService.java
@@ -1,0 +1,32 @@
+package com.hobak.happinessql.domain.activity.application;
+
+import com.hobak.happinessql.domain.activity.converter.ActivityConverter;
+import com.hobak.happinessql.domain.activity.domain.Activity;
+import com.hobak.happinessql.domain.activity.domain.Category;
+import com.hobak.happinessql.domain.activity.dto.ActivityCreateRequestDto;
+import com.hobak.happinessql.domain.activity.dto.ActivityCreateResponseDto;
+import com.hobak.happinessql.domain.activity.repository.ActivityRepository;
+import com.hobak.happinessql.domain.activity.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ActivityCreateService {
+
+    private final ActivityRepository activityRepository;
+    private final CategoryRepository categoryRepository;
+    public ActivityCreateResponseDto createActivity(ActivityCreateRequestDto requestDto,Long userId) {
+        Category category = categoryRepository.findByUserId(userId);
+
+        Long nextActivityId = activityRepository.findNextActivityId();
+        Activity activity = new Activity(nextActivityId, requestDto.getActivityName(), category);
+
+        Activity savedActivity = activityRepository.save(activity);
+        return ActivityConverter.toActivityCreateResponseDto(savedActivity.getActivityId());
+
+    }
+}

--- a/src/main/java/com/hobak/happinessql/domain/activity/converter/ActivityConverter.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/converter/ActivityConverter.java
@@ -2,6 +2,7 @@ package com.hobak.happinessql.domain.activity.converter;
 
 import com.hobak.happinessql.domain.activity.domain.Activity;
 import com.hobak.happinessql.domain.activity.domain.Category;
+import com.hobak.happinessql.domain.activity.dto.ActivityCreateResponseDto;
 import com.hobak.happinessql.domain.activity.dto.ActivityDto;
 import com.hobak.happinessql.domain.activity.dto.CategoryDto;
 
@@ -32,11 +33,9 @@ public class ActivityConverter {
                 .build();
     }
 
-    public static CategoryDto toCategoryDtoWithActivities(Category category, List<Activity> activities) {
-        return CategoryDto.builder()
-                .id(category.getCategoryId())
-                .name(category.getName())
-                .activities(toActivityDtoList(activities))
+    public static ActivityCreateResponseDto toActivityCreateResponseDto(Long activityId){
+        return ActivityCreateResponseDto.builder()
+                .activityId(activityId)
                 .build();
     }
 }

--- a/src/main/java/com/hobak/happinessql/domain/activity/domain/Activity.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/domain/Activity.java
@@ -27,7 +27,7 @@ public class Activity extends BaseTimeEntity {
     @Column
     private String emoji;
 
-    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL/*, orphanRemoval = true*/)
     private List<Record> records;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityCreateRequestDto.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityCreateRequestDto.java
@@ -1,0 +1,18 @@
+package com.hobak.happinessql.domain.activity.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityCreateRequestDto {
+    private String category;
+    private String activityName;
+    @Builder
+    ActivityCreateRequestDto(String category, String activityName){
+        this.category = category;
+        this.activityName = activityName;
+    }
+}

--- a/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityCreateResponseDto.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityCreateResponseDto.java
@@ -1,0 +1,16 @@
+package com.hobak.happinessql.domain.activity.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityCreateResponseDto {
+    private Long activityId;
+    @Builder
+    ActivityCreateResponseDto(Long activityId){
+        this.activityId = activityId;
+    }
+}

--- a/src/main/java/com/hobak/happinessql/domain/activity/repository/ActivityRepository.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/repository/ActivityRepository.java
@@ -2,7 +2,6 @@ package com.hobak.happinessql.domain.activity.repository;
 
 import com.hobak.happinessql.domain.activity.domain.Activity;
 import com.hobak.happinessql.domain.activity.domain.Category;
-import com.hobak.happinessql.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,6 +9,6 @@ import java.util.List;
 
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
     List<Activity> findByCategory(Category category);
-    @Query("SELECT MAX(a.activityId) FROM Activity a")
-    Long findMaxActivityId();
+    @Query(value = "SELECT MAX(a.activityId) + 1 FROM Activity a")
+    Long findNextActivityId();
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #38

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

활동 추가 API를 구현했습니다. 
- /api/activities?userId=45 로 요청하면 다음과 같은 응답을 받을 수 있습니다.
<img width="637" alt="image" src="https://github.com/Happy-HOBAK/happinesSQL-BE/assets/147161502/924c9c06-e7ef-4084-a87e-6523c4485903">

```
{
  "success": true,
  "code": 0,
  "message": "활동을 성공적으로 추가했습니다.",
  "data": {
    "activityId": 98
  }
}
``` 

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<img width="952" alt="image" src="https://github.com/Happy-HOBAK/happinesSQL-BE/assets/147161502/43b7b5ba-fd21-4a2e-9865-583661648309">
 
```
@Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "activity_id")
    private Long activityId;
``` 
위 코드는 Activity 도메인의 일부입니다. @GeneratedValue으로 인해 추가되는 활동의 activity_id가 현재 테이블에서 가장 큰 값 + 1이 아닌, 데이터베이스가 자동으로 생성한 id 값 중에서 최대값을 찾아서 +1을 한 값으로 저장되고 있습니다. 이 부분을 수정해야 하는지 고민이 됩니다...... @GeneratedValue가 없도록 수정한다면 위의 예시가 activity_id 98번이 아닌 8번으로 저장되었을 겁니다! 

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
