### PR TITLE
[#55] 활동 삭제 API 구현

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
@@ -29,8 +29,8 @@ public class ActivityController {
         ActivityCreateResponseDto response = activityCreateService.createActivity(request,userId);
         return DataResponseDto.of(response,"활동을 성공적으로 추가했습니다.");
     }
-    @DeleteMapping
-    public Long deleteActivity(@RequestParam Long activityId){
+    @DeleteMapping("/{activityId}")
+    public Long deleteActivity(@PathVariable Long activityId){
         activityDeleteService.deleteActivity(activityId);
         return activityId;
     }

--- a/src/main/java/com/hobak/happinessql/domain/activity/application/ActivityDeleteService.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/application/ActivityDeleteService.java
@@ -2,6 +2,7 @@ package com.hobak.happinessql.domain.activity.application;
 
 
 import com.hobak.happinessql.domain.activity.domain.Activity;
+import com.hobak.happinessql.domain.activity.exception.ActivityNotFoundException;
 import com.hobak.happinessql.domain.activity.repository.ActivityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,7 @@ public class ActivityDeleteService {
     private final ActivityRepository activityRepository;
     public void deleteActivity(Long activityId){
         Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(()->new IllegalArgumentException("해당 활동이 존재하지 않습니다. activityId: " + activityId));
+                .orElseThrow(()->new ActivityNotFoundException("Activity with id " + activityId));
         activityRepository.delete(activity);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #55

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

활동 삭제 API를 구현했습니다!
파라미터로 들어온 activityId의 활동을 삭제합니다. 삭제 후에는 삭제한 activityId를 반환합니다.
- /api/activities?activityId=103 로 요청 시 다음과 같은 답변을 받을 수 있습니다.
```
103
``` 


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
