### PR TITLE
[#57] 활동 수정 API 구현

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
@@ -2,9 +2,8 @@ package com.hobak.happinessql.domain.activity.api;
 
 import com.hobak.happinessql.domain.activity.application.ActivityCreateService;
 import com.hobak.happinessql.domain.activity.application.ActivityDeleteService;
-import com.hobak.happinessql.domain.activity.dto.ActivityCreateRequestDto;
-import com.hobak.happinessql.domain.activity.dto.ActivityCreateResponseDto;
-import com.hobak.happinessql.domain.activity.dto.ActivityListResponseDto;
+import com.hobak.happinessql.domain.activity.application.ActivityUpdateService;
+import com.hobak.happinessql.domain.activity.dto.*;
 import com.hobak.happinessql.domain.activity.application.ActivityListService;
 import com.hobak.happinessql.global.response.DataResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,7 @@ public class ActivityController {
     private final ActivityListService activityListService;
     private final ActivityCreateService activityCreateService;
     private final ActivityDeleteService activityDeleteService;
-
+    private final ActivityUpdateService activityUpdateService;
     @GetMapping
     public DataResponseDto<ActivityListResponseDto> getActivitiesByUserId(@RequestParam Long userId) {
         ActivityListResponseDto response = activityListService.getActivitiesByUserId(userId);
@@ -33,5 +32,10 @@ public class ActivityController {
     public Long deleteActivity(@PathVariable Long activityId){
         activityDeleteService.deleteActivity(activityId);
         return activityId;
+    }
+    @PutMapping("/{activityId}")
+    public DataResponseDto<ActivityUpdateResponseDto> updateActicity(@PathVariable Long activityId, @RequestBody ActivityUpdateRequestDto requestDto){
+        ActivityUpdateResponseDto responseDto = activityUpdateService.updateActivity(activityId,requestDto);
+        return DataResponseDto.of(responseDto,"활동을 성공적으로 수정했습니다.");
     }
 }

--- a/src/main/java/com/hobak/happinessql/domain/activity/application/ActivityUpdateService.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/application/ActivityUpdateService.java
@@ -1,0 +1,26 @@
+package com.hobak.happinessql.domain.activity.application;
+
+import com.hobak.happinessql.domain.activity.converter.ActivityConverter;
+import com.hobak.happinessql.domain.activity.domain.Activity;
+import com.hobak.happinessql.domain.activity.dto.ActivityUpdateRequestDto;
+import com.hobak.happinessql.domain.activity.dto.ActivityUpdateResponseDto;
+import com.hobak.happinessql.domain.activity.exception.ActivityNotFoundException;
+import com.hobak.happinessql.domain.activity.repository.ActivityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ActivityUpdateService {
+    private final ActivityRepository activityRepository;
+
+    public ActivityUpdateResponseDto updateActivity(Long activityId, ActivityUpdateRequestDto requestDto){
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(()-> new ActivityNotFoundException("Activity with id " + activityId));
+        activity.updateName(requestDto.getName());
+        return ActivityConverter.toActivityUpdateResponseDto(activity);
+    }
+
+}

--- a/src/main/java/com/hobak/happinessql/domain/activity/converter/ActivityConverter.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/converter/ActivityConverter.java
@@ -4,6 +4,7 @@ import com.hobak.happinessql.domain.activity.domain.Activity;
 import com.hobak.happinessql.domain.activity.domain.Category;
 import com.hobak.happinessql.domain.activity.dto.ActivityCreateResponseDto;
 import com.hobak.happinessql.domain.activity.dto.ActivityDto;
+import com.hobak.happinessql.domain.activity.dto.ActivityUpdateResponseDto;
 import com.hobak.happinessql.domain.activity.dto.CategoryDto;
 
 import java.util.List;
@@ -36,6 +37,14 @@ public class ActivityConverter {
     public static ActivityCreateResponseDto toActivityCreateResponseDto(Long activityId){
         return ActivityCreateResponseDto.builder()
                 .activityId(activityId)
+                .build();
+    }
+    public static ActivityUpdateResponseDto toActivityUpdateResponseDto(Activity activity){
+        return ActivityUpdateResponseDto.builder()
+                .categoryId(activity.getCategory().getCategoryId())
+                .categoryName(activity.getCategory().getName())
+                .activityId(activity.getActivityId())
+                .activityName(activity.getName())
                 .build();
     }
 }

--- a/src/main/java/com/hobak/happinessql/domain/activity/domain/Activity.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/domain/Activity.java
@@ -40,5 +40,8 @@ public class Activity extends BaseTimeEntity {
         this.name = name;
         this.category = category;
     }
+    public void updateName(String name){
+        this.name = name;
+    }
 }
 

--- a/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityUpdateRequestDto.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.hobak.happinessql.domain.activity.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityUpdateRequestDto {
+    String name;
+    @Builder
+    ActivityUpdateRequestDto(String name){
+        this.name = name;
+    }
+}

--- a/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityUpdateResponseDto.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityUpdateResponseDto.java
@@ -1,0 +1,22 @@
+package com.hobak.happinessql.domain.activity.dto;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+public class ActivityUpdateResponseDto {
+    private Long categoryId;
+    private String categoryName;
+    private Long activityId;
+    private String activityName;
+    @Builder
+    ActivityUpdateResponseDto(Long categoryId, String categoryName, Long activityId, String activityName){
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+        this.activityId = activityId;
+        this.activityName = activityName;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #57

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

활동 수정 API를 구현했습니다. 
/api/activities/109 로 요청시 다음과 같은 응답을 받을 수 있습니다.
- Request Body
```
{
  "name": "수정하기"
}
```
- Responses
```
{
  "success": true,
  "code": 0,
  "message": "활동을 성공적으로 수정했습니다.",
  "data": {
    "categoryId": 78,
    "categoryName": "기타",
    "activityId": 109,
    "activityName": "수정하기"
  }
}
``` 

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
