### PR TITLE
[#65] Location의 위도, 경도 속성명 수정 

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/record/converter/RecordConverter.java
+++ b/src/main/java/com/hobak/happinessql/domain/record/converter/RecordConverter.java
@@ -28,8 +28,8 @@ public class RecordConverter {
                 .city(recordRequestDto.getCity())
                 .country(recordRequestDto.getCountry())
                 .district(recordRequestDto.getDistrict())
-                .xPos(recordRequestDto.getXPos())
-                .yPos(recordRequestDto.getYPos())
+                .latitude(recordRequestDto.getLatitude())
+                .longitude(recordRequestDto.getLongitude())
                 .record(record)
                 .build();
     }

--- a/src/main/java/com/hobak/happinessql/domain/record/domain/Location.java
+++ b/src/main/java/com/hobak/happinessql/domain/record/domain/Location.java
@@ -31,23 +31,23 @@ public class Location extends BaseTimeEntity {
     private String district;
 
     @Column(nullable = false)
-    private Double xPos;
+    private Double latitude;
 
     @Column(nullable = false)
-    private Double yPos;
+    private Double longitude;
 
     @OneToOne
     @JoinColumn(name = "record_id", nullable = false)
     private Record record;
 
     @Builder
-    public Location(String fullName, String country, String city, String district, Double xPos, Double yPos, Record record) {
+    public Location(String fullName, String country, String city, String district, Double latitude, Double longitude, Record record) {
         this.fullName = fullName;
         this.country = country;
         this.city = city;
         this.district = district;
-        this.xPos = xPos;
-        this.yPos = yPos;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.record = record;
     }
 }

--- a/src/main/java/com/hobak/happinessql/domain/record/dto/RecordCreateRequestDto.java
+++ b/src/main/java/com/hobak/happinessql/domain/record/dto/RecordCreateRequestDto.java
@@ -33,10 +33,8 @@ public class RecordCreateRequestDto {
     private String district;
 
     @NotNull
-    @JsonProperty("x_pos")
-    private Double xPos;
+    private Double latitude;
 
     @NotNull
-    @JsonProperty("y_pos")
-    private Double yPos;
+    private Double longitude;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #65 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- `POST /api/records` API에서 x_pos와 y_pos 값을 두 번 입력해야 하는 이슈가 있어 이를 해결하였습니다.
- `@JsonProperty`를 없애주는 방법도 있지만, x_pos, y_pos보다는 프론트엔드에서 사용하는 라이브러리에 맞게 각각 위도, 경도를 나타내는 latitude와 longitude로 속성명을 변경하는 것이 더 낫겠다고 판단하여 위도, 경도 속성명을 수정합니다.

수정한 request body 예시는 다음과 같습니다.
```json
{
  "happiness": 0,
  "memo": "string",
  "country": "string",
  "city": "string",
  "district": "string",
  "latitude": 0,
  "longitude": 0,
  "activity_id": 0,
  "full_name": "string"
}
```

> JSON 키 값이 두 개가 나타난 오류에 대한 자료는 많지는 않지만, [이 글](https://github.com/FasterXML/jackson-databind/issues/1609)이 가장 잘 설명하는 것 같습니다. getXPos에서 get하는 것이 XPos(xpos)일 수도, xPos(x_pos)일 수도 있기 때문에 생기는 문제 같은데... 혼란이 없기 위해서는 latitude와 longitude를 쓰는 게 제일 좋을 것 같습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 브랜치명 잘못 설정한 건.. 흐린 눈 해주세요,,, 🫠 💛

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
