### PR TITLE
[#83] Activity 엔티티의 description 필드의 태그 공백 기준으로 파싱해서 보내주기

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/activity/converter/ActivityConverter.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/converter/ActivityConverter.java
@@ -3,6 +3,7 @@ package com.hobak.happinessql.domain.activity.converter;
 import com.hobak.happinessql.domain.activity.domain.Activity;
 import com.hobak.happinessql.domain.activity.domain.Category;
 import com.hobak.happinessql.domain.activity.dto.*;
+import com.hobak.happinessql.global.util.StringParser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +19,7 @@ public class ActivityConverter {
     }
     public static ActivityDto toActivityDto(Activity activity) {
         return ActivityDto.builder()
-                .description(activity.getDescription())
+                .description(StringParser.extractTags(activity.getDescription()))
                 .id(activity.getActivityId())
                 .name(activity.getName())
                 .emoji(activity.getEmoji())

--- a/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityDto.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/dto/ActivityDto.java
@@ -5,16 +5,18 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ActivityDto {
     private Long id;
     private String name;
-    private String description;
+    private List<String> description;
     private String emoji;
 
     @Builder
-    public ActivityDto(Long id, String name, String description, String emoji) {
+    public ActivityDto(Long id, String name, List<String> description, String emoji) {
         this.id = id;
         this.name = name;
         this.description = description;

--- a/src/main/java/com/hobak/happinessql/global/util/StringParser.java
+++ b/src/main/java/com/hobak/happinessql/global/util/StringParser.java
@@ -1,0 +1,14 @@
+package com.hobak.happinessql.global.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class StringParser {
+    public static List<String> extractTags(String description)  {
+        if(description == null || description.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(description.split(" "));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- description의 태그들을 공백 기준으로 분리해서 리스트 형태로 보내줍니다.

- description을 보내주는 API에서는 모두 다음과 비슷한 응답을 받을 수 있습니다.
```json
{
  "activities": [
            {
              "id": 21,
              "name": "책 읽기",
              "description": [
                "#책먹는",
                "#여우"
              ],
              "emoji": "📚"
            },
            // 생략
  ]
}
```
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
