### PR TITLE
[#81] JWT 토큰으로 유저 정보 가져오도록 수정

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
+++ b/src/main/java/com/hobak/happinessql/domain/activity/api/ActivityController.java
@@ -3,10 +3,14 @@ package com.hobak.happinessql.domain.activity.api;
 import com.hobak.happinessql.domain.activity.application.*;
 import com.hobak.happinessql.domain.activity.converter.ActivityConverter;
 import com.hobak.happinessql.domain.activity.dto.*;
+import com.hobak.happinessql.domain.user.application.UserFindService;
+import com.hobak.happinessql.domain.user.domain.User;
 import com.hobak.happinessql.global.response.DataResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name="Activity", description = "활동 관련 REST API에 대한 명세를 제공합니다.")
@@ -20,17 +24,22 @@ public class ActivityController {
     private final ActivityDeleteService activityDeleteService;
     private final ActivityUpdateService activityUpdateService;
     private final ActivitySearchService activitySearchService;
+    private final UserFindService userFindService;
 
     @Operation(summary = "활동 리스트 조회", description = "유저가 가지고 있는 활동 목록을 조회합니다. 행복 기록 생성 시 활동 선택 창에서 사용하는 API입니다.")
     @GetMapping
-    public DataResponseDto<ActivityListResponseDto> getActivities(@RequestParam Long userId) {
+    public DataResponseDto<ActivityListResponseDto> getActivities(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = userFindService.findByUserDetails(userDetails);
+        Long userId = user.getUserId();
         ActivityListResponseDto response = activityListService.getActivities(userId);
         return DataResponseDto.of(response, "사용자의 모든 카테고리별 활동을 성공적으로 조회했습니다.");
     }
 
     @Operation(summary = "활동 추가", description = "기타 카테고리에 활동을 추가합니다.")
     @PostMapping
-    public DataResponseDto<ActivityResponseDto> createActivity(@RequestBody ActivityCreateRequestDto requestDto, @RequestParam Long userId){
+    public DataResponseDto<ActivityResponseDto> createActivity(@RequestBody ActivityCreateRequestDto requestDto, @AuthenticationPrincipal UserDetails userDetails){
+        User user = userFindService.findByUserDetails(userDetails);
+        Long userId = user.getUserId();
         ActivityResponseDto responseDto = activityCreateService.createActivity(requestDto,userId);
         return DataResponseDto.of(responseDto,"활동을 성공적으로 추가했습니다.");
     }
@@ -52,7 +61,9 @@ public class ActivityController {
 
     @Operation(summary = "활동 검색", description = "유저가 갖고 있는 활동을 검색합니다. (활동의 description에 있는 내용은 아직 검색되지 않습니다.)")
     @PostMapping("/search")
-    public DataResponseDto<ActivitySearchResponseDto> searchActivities(@RequestBody ActivitySearchRequestDto requestDto, @RequestParam Long userId) {
+    public DataResponseDto<ActivitySearchResponseDto> searchActivities(@RequestBody ActivitySearchRequestDto requestDto, @AuthenticationPrincipal UserDetails userDetails) {
+        User user = userFindService.findByUserDetails(userDetails);
+        Long userId = user.getUserId();
         ActivitySearchResponseDto responseDto = activitySearchService.searchActivities(requestDto.getSearch(), userId);
         return DataResponseDto.of(responseDto, "활동을 성공적으로 검색했습니다.");
     }

--- a/src/main/java/com/hobak/happinessql/domain/user/api/UserController.java
+++ b/src/main/java/com/hobak/happinessql/domain/user/api/UserController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
@@ -23,29 +24,24 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("api/users")
 public class UserController {
 
-    private final UserFindService userFindService;
     private final UserProfileService userProfileService;
     private final UserService userService;
     private final CustomUserDetailsService customUserDetailsService;
+    private final CategoryCreateService categoryCreateService;
+    private final UserFindService userFindService;
 
     @NonNull
     private PasswordEncoder passwordEncoder;
     @GetMapping("/profile")
-    public DataResponseDto<Object> getUserInfo() {
-        // TODO : 임시값 -> 로그인한 유저의 id를 찾아내는 로직으로 변경
-        Long userId = 1L;
-
-        User user = userFindService.findUserById(userId);
+    public DataResponseDto<Object> getUserInfo(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = userFindService.findByUserDetails(userDetails);
         UserInfoResponseDto userInfoResponseDto = UserConverter.toUserInfoResponseDto(user);
-
         return DataResponseDto.of(userInfoResponseDto, "유저 프로필을 성공적으로 조회했습니다.");
     }
 
     @PutMapping("/profile")
-    public DataResponseDto<Object> updateUserInfo(@RequestBody @Valid UserProfileUpdateRequestDto requestDto) {
-        Long userId = 1L;
-
-        User user = userFindService.findUserById(userId);
+    public DataResponseDto<Object> updateUserInfo(@RequestBody @Valid UserProfileUpdateRequestDto requestDto, @AuthenticationPrincipal UserDetails userDetails) {
+        User user = userFindService.findByUserDetails(userDetails);
         User updatedUser = userProfileService.updateUserProfile(user, requestDto);
         UserInfoResponseDto responseDto = UserConverter.toUserInfoResponseDto(updatedUser);
 
@@ -62,11 +58,6 @@ public class UserController {
 
     }
 
-    @PostMapping("/test")
-    public String test(){
-        return "success";
-    }
-    private final CategoryCreateService categoryCreateService;
     @PostMapping("/sign-up")
     public DataResponseDto<Object> signUp(@RequestBody SignUpDto signUpDto){
         UserDto savedUserDto = userService.signUp(signUpDto);

--- a/src/main/java/com/hobak/happinessql/domain/user/application/UserFindService.java
+++ b/src/main/java/com/hobak/happinessql/domain/user/application/UserFindService.java
@@ -4,6 +4,7 @@ import com.hobak.happinessql.domain.user.domain.User;
 import com.hobak.happinessql.domain.user.exception.UserNotFoundException;
 import com.hobak.happinessql.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,5 +16,9 @@ public class UserFindService {
     public User findUserById(Long userId) {
         return userRespository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("User with ID" + userId));
+    }
+
+    public User findByUserDetails(UserDetails userDetails){
+        return userRespository.findUserByusername(userDetails.getUsername());
     }
 }

--- a/src/main/java/com/hobak/happinessql/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/hobak/happinessql/domain/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Boolean existsByUsername(String username);
+    User findUserByusername(String username);
 }

--- a/src/main/java/com/hobak/happinessql/global/auth/JwtTokenProvider.java
+++ b/src/main/java/com/hobak/happinessql/global/auth/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.hobak.happinessql.global.auth;
 
+import com.hobak.happinessql.domain.user.application.*;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -8,14 +9,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
-
 import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
 
@@ -23,9 +19,11 @@ import java.util.stream.Collectors;
 @Component
 public class JwtTokenProvider {
     private final Key key;
-    public JwtTokenProvider(@Value("${jwt.secret}")String secretKey){
+    private final CustomUserDetailsService customUserDetailsService;
+    public JwtTokenProvider(@Value("${jwt.secret}")String secretKey, CustomUserDetailsService customUserDetailsService){
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.customUserDetailsService = customUserDetailsService;
     }
     // Member 정보를 가지고 AccessToken, RefreshToken을 생성하는 메서드
     public JwtToken generateToken(Authentication authentication) {
@@ -60,22 +58,9 @@ public class JwtTokenProvider {
 
     // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
     public Authentication getAuthentication(String accessToken) {
-        // Jwt 토큰 복호화
         Claims claims = parseClaims(accessToken);
-
-        if (claims.get("auth") == null) {
-            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
-        }
-
-        // 클레임에서 권한 정보 가져오기
-        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split(","))
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
-
-        // UserDetails 객체를 만들어서 Authentication return
-        // UserDetails: interface, User: UserDetails를 구현한 class
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
-        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(claims.getSubject());
+        return new UsernamePasswordAuthenticationToken(userDetails, accessToken, userDetails.getAuthorities());
     }
 
     // 토큰 정보를 검증하는 메서드


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #81

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

@AuthenticationPrincipal을 이용하여 임시로 userId를 직접 사용하던 기존의 방식을 jwt 토큰으로 유저의 정보를 가져오는 방식으로 수정했습니다!
로그인 시 accessToken과 refreshToken을 확인할 수 있습니다. accessToken으로 인증을 진행하면 userId를 직접 입력하지 않아도 해당 유저의 정보들을 기반으로 기능들이 동작합니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
