### PR TITLE
[#103] 전체, 연간, 월간 모든 위치 데이터 랭킹 조회 API 구축

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/report/api/ReportController.java
+++ b/src/main/java/com/hobak/happinessql/domain/report/api/ReportController.java
@@ -144,4 +144,28 @@ public class ReportController {
         return DataResponseDto.of(responseDto, "월간 활동 행복도 순위를 성공적으로 조회했습니다.");
     }
 
+    @Operation(summary = "[전체] 모든 위치의 행복도 순위", description = "전체 기록에서 모든 위치의 행복도 순위를 제공합니다.")
+    @GetMapping("/all/ranking/locations")
+    public DataResponseDto<List<LocationHappinessDto>> getAllLocationRankings(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = userFindService.findByUserDetails(userDetails);
+        List<LocationHappinessDto> responseDto = reportLocationRankingService.getAllLocationRankings(user);
+        return DataResponseDto.of(responseDto, "전체 위치 행복도 순위를 성공적으로 조회했습니다.");
+    }
+
+    @Operation(summary = "[연간] 모든 위치의 행복도 순위", description = "이번 해 모든 위치의 행복도 순위를 제공합니다.")
+    @GetMapping("/year/ranking/locations")
+    public DataResponseDto<List<LocationHappinessDto>> getYearlyLocationRankings(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = userFindService.findByUserDetails(userDetails);
+        List<LocationHappinessDto> responseDto = reportLocationRankingService.getYearlyLocationRankings(user);
+        return DataResponseDto.of(responseDto, "연간 위치 행복도 순위를 성공적으로 조회했습니다.");
+    }
+
+    @Operation(summary = "[월간] 모든 위치의 행복도 순위", description = "이번 달 모든 위치의 행복도 순위를 제공합니다.")
+    @GetMapping("/month/ranking/locations")
+    public DataResponseDto<List<LocationHappinessDto>> getMonthlyLocationRankings(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = userFindService.findByUserDetails(userDetails);
+        List<LocationHappinessDto> responseDto = reportLocationRankingService.getMonthlyLocationRankings(user);
+        return DataResponseDto.of(responseDto, "월간 위치 행복도 순위를 성공적으로 조회했습니다.");
+    }
+
 }

--- a/src/main/java/com/hobak/happinessql/domain/report/application/LocationHappinessAnalyzer.java
+++ b/src/main/java/com/hobak/happinessql/domain/report/application/LocationHappinessAnalyzer.java
@@ -48,6 +48,20 @@ public class LocationHappinessAnalyzer {
             return locationRankings;
         }
 
+        locationRankings = getLocationRankings(records);
+        // 만약 topCount보다 적게 선정된 경우, 나머지 빈 항목 추가
+        while (locationRankings.size() < topCount) {
+            locationRankings.add(ReportConverter.toLocationHappinessDto(locationRankings.size() + 1, null));
+        }
+
+        return locationRankings.stream()
+                .limit(topCount)
+                .collect(Collectors.toList());
+    }
+
+    public static List<LocationHappinessDto> getLocationRankings(List<Record> records) {
+        List<LocationHappinessDto> locationRankings = new ArrayList<>();
+
         // 도시와 구를 기준으로 Record 그룹화
         Map<String, List<Record>> locationRecordsMap = groupRecordsByLocation(records);
 
@@ -59,15 +73,10 @@ public class LocationHappinessAnalyzer {
         List<String> sortedLocations = sortLocations(locationAverageHappiness, locationFrequency);
 
         // 상위 N개의 위치 선정
-        for (int i = 0; i < Math.min(topCount, sortedLocations.size()); i++) {
+        for (int i = 0; i < sortedLocations.size(); i++) {
             String location = sortedLocations.get(i);
             LocationHappinessDto locationDto = ReportConverter.toLocationHappinessDto(i + 1, location);
             locationRankings.add(locationDto);
-        }
-
-        // 만약 topCount보다 적게 선정된 경우, 나머지 빈 항목 추가
-        while (locationRankings.size() < topCount) {
-            locationRankings.add(ReportConverter.toLocationHappinessDto(locationRankings.size() + 1, null));
         }
 
         return locationRankings;

--- a/src/main/java/com/hobak/happinessql/domain/report/application/ReportLocationRankingService.java
+++ b/src/main/java/com/hobak/happinessql/domain/report/application/ReportLocationRankingService.java
@@ -38,4 +38,29 @@ public class ReportLocationRankingService {
         List<Record> records = recordRepository.findAllByCreatedAtBetweenAndUser(startOfMonthDateTime, endOfMonthDateTime, user);
         return LocationHappinessAnalyzer.getLocationRankings(records, 3);
     }
+
+    public List<LocationHappinessDto> getAllLocationRankings(User user) {
+        List<Record> records = recordRepository.findAllByUser(user);
+        return LocationHappinessAnalyzer.getLocationRankings(records);
+    }
+
+    public List<LocationHappinessDto> getYearlyLocationRankings(User user) {
+        int currentYear = LocalDate.now().getYear();
+        LocalDateTime startOfYear = LocalDateTime.of(currentYear, 1, 1, 0, 0);
+        LocalDateTime endOfYear = LocalDateTime.of(currentYear, 12, 31, 23, 59, 59);
+        List<Record> records = recordRepository.findAllByCreatedAtBetweenAndUser(startOfYear, endOfYear, user);
+        return LocationHappinessAnalyzer.getLocationRankings(records);
+    }
+
+    public List<LocationHappinessDto> getMonthlyLocationRankings(User user) {
+        LocalDate today = LocalDate.now();
+        LocalDate startOfMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate endOfMonth = LocalDate.now().withDayOfMonth(today.lengthOfMonth());
+        LocalDateTime startOfMonthDateTime = startOfMonth.atStartOfDay();
+        LocalDateTime endOfMonthDateTime = endOfMonth.atTime(23, 59, 59);
+        List<Record> records = recordRepository.findAllByCreatedAtBetweenAndUser(startOfMonthDateTime, endOfMonthDateTime, user);
+        return LocationHappinessAnalyzer.getLocationRankings(records);
+    }
+
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #103 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- 전체, 연간, 월간 모든 위치 랭킹 조회 API를 구축했습니다.

- 기존 `getLocationRankings` 메서드를 오버로딩하여 두 가지 버전으로 분리했습니다.

  record 리스트와 topCount를 인자로 함께 받는 메서드는 topCount 파라미터를 받아 상위 N개의 활동 랭킹을 반환합니다.
  record 리스트만 인자로 받는 메서드는 topCount 파라미터 없이 모든 활동 랭킹을 반환합니다. 이 메서드는 존재하는 데이터까지만 반환하며, 데이터가 없는 경우 null 값을 반환하지 않습니다.


api/report/all/ranking/locations로 요청 시 다음과 같은 결과를 얻을 수 있습니다.

    
```json
{
  "success": true,
  "code": 0,
  "message": "전체 시간대 행복도 순위를 성공적으로 조회했습니다.",
  "data": [
    {
      "ranking": 1,
      "time_of_day": "새벽"
    },
    {
      "ranking": 2,
      "time_of_day": "아침"
    },
    {
      "ranking": 3,
      "time_of_day": "저녁"
    },
    {
      "ranking": 4,
      "time_of_day": "낮"
    },
    {
      "ranking": 5,
      "time_of_day": "밤"
    }
  ]
}
```


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
