### PR TITLE
[#118] 날짜 오류 수정

### DIFF
--- a/src/main/java/com/hobak/happinessql/domain/report/application/AverageHappinessService.java
+++ b/src/main/java/com/hobak/happinessql/domain/report/application/AverageHappinessService.java
@@ -43,7 +43,7 @@ public class AverageHappinessService {
         return ReportConverter.toAverageHappinessResponseDto(averageHappiness,level,level.getEmoji());    }
     public AverageHappinessResponseDto getMonthlyHappiness(User user) {
         LocalDateTime startOfMonth = LocalDateTime.of(currentYear, currentMonth, 1, 0, 0);
-        LocalDateTime endOfMonth = LocalDateTime.of(currentYear, currentMonth, 31, 23, 59, 59);
+        LocalDateTime endOfMonth = LocalDateTime.of(currentYear, currentMonth, currentDate.lengthOfMonth(), 23, 59, 59);
         double totalHappiness = recordRepository.findAllByCreatedAtBetweenAndUser(startOfMonth, endOfMonth, user).stream().mapToInt(Record::getHappiness).sum();
         double averageHappiness = totalHappiness / recordRepository.countAllByCreatedAtBetweenAndUser(startOfMonth, endOfMonth, user);
         averageHappiness = Math.round(averageHappiness * 100.0) / 100.0;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #118

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

31일이 없는 달에 31일까지의 데이터를 조회하기에 발생하는 오류를 해결했습니다.
달의 마지막 날을 31이 아닌, currentDate.lengthOfMonth()로 수정했습니다!

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
