### PR TITLE
[#122] 프로필 수정 시 이름도 함께 수정하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     compileOnly 'org.projectlombok:lombok'
@@ -47,7 +43,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-//    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hobak/happinessql/domain/user/domain/User.java
+++ b/src/main/java/com/hobak/happinessql/domain/user/domain/User.java
@@ -79,5 +79,6 @@ public class User extends BaseTimeEntity implements UserDetails {
     public void updateUserProfile(UserProfileUpdateRequestDto requestDto) {
         this.gender = requestDto.getGender();
         this.age = requestDto.getAge();
+        this.name = requestDto.getName();
     }
 }

--- a/src/main/java/com/hobak/happinessql/domain/user/dto/UserProfileUpdateRequestDto.java
+++ b/src/main/java/com/hobak/happinessql/domain/user/dto/UserProfileUpdateRequestDto.java
@@ -15,5 +15,7 @@ public class UserProfileUpdateRequestDto {
     @Min(1)
     private int age;
 
+    private String name;
+
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #122

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- 프로필 수정 시 이름도 함께 수정하도록 DTO와 `updateUserProfile` 메서드 로직을 수정했습니다.
- `build.gradle`에서 사용하지 않는 의존성을 삭제했습니다.

/api/users/profile로 요청 시 다음과 같은 응답을 받을 수 있습니다.
```json
{
  "success": true,
  "code": 0,
  "message": "유저 프로필을 성공적으로 수정했습니다.",
  "data": {
    "userId": 29,
    "name": "해피니스큐엘",
    "gender": "남성",
    "age": 22
  }
}
```

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
