### PR TITLE
[#125] 감정어 분석 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -43,6 +44,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Gson 라이브러리로 Json 파싱
+    implementation 'org.jsoup:jsoup:1.14.2'
+    implementation 'com.google.code.gson:gson:2.8.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hobak/happinessql/domain/record/application/SentimentAnalyzeService.java
+++ b/src/main/java/com/hobak/happinessql/domain/record/application/SentimentAnalyzeService.java
@@ -1,0 +1,85 @@
+package com.hobak.happinessql.domain.record.application;
+
+import com.google.gson.JsonObject;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class SentimentAnalyzeService {
+    @Value("${sentiment.clientId}")
+    private String clientId;
+
+    @Value("${sentiment.clientSecret}")
+    private String clientSecret;
+
+    public Map<String, List<String>> getAnalyzeResult(String content) {
+        String url = "https://naveropenapi.apigw.ntruss.com/sentiment-analysis/v1/analyze";
+
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.add("X-NCP-APIGW-API-KEY-ID", clientId);
+            headers.add("X-NCP-APIGW-API-KEY", clientSecret);
+
+            JsonObject jsonObject = new JsonObject();
+            jsonObject.addProperty("content", content);
+
+            HttpEntity<String> entity = new HttpEntity<>(jsonObject.toString(), headers);
+
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    entity,
+                    new ParameterizedTypeReference<Map<String, Object>>() {}
+            );
+
+            Map<String, Object> responseBody = response.getBody();
+            if (responseBody != null && responseBody.containsKey("sentences")) {
+                List<Map<String, Object>> sentences = (List<Map<String, Object>>) responseBody.get("sentences");
+                List<Map<String, String>> emotionText = sentences.stream()
+                        .map(sentence -> Map.of(
+                                "content", (String) sentence.get("content"),
+                                "sentiment", (String) sentence.get("sentiment")
+                        ))
+                        .collect(Collectors.toList());
+
+                return separateSentiment(emotionText);
+            } else {
+                log.warn("Response does not contain 'sentences' key");
+                return Map.of("positive", List.of(), "negative", List.of());
+            }
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            log.error("HTTP error: " + e.toString());
+            return Map.of("positive", List.of(), "negative", List.of());
+        } catch (Exception e) {
+            log.error("Unexpected error: " + e.toString());
+            return Map.of("positive", List.of(), "negative", List.of());
+        }
+    }
+
+    private Map<String, List<String>> separateSentiment(List<Map<String, String>> emotionText) {
+        Map<String, List<String>> groupedTexts = emotionText.stream()
+                .collect(Collectors.groupingBy(
+                        map -> map.get("sentiment"),
+                        Collectors.mapping(map -> map.get("content"), Collectors.toList())
+                ));
+
+        List<String> positive = groupedTexts.getOrDefault("positive", List.of());
+        List<String> negative = groupedTexts.getOrDefault("negative", List.of());
+
+        return Map.of("positive", positive, "negative", negative);
+    }
+}

--- a/src/main/java/com/hobak/happinessql/domain/record/domain/Analysis.java
+++ b/src/main/java/com/hobak/happinessql/domain/record/domain/Analysis.java
@@ -1,0 +1,45 @@
+package com.hobak.happinessql.domain.record.domain;
+
+import com.hobak.happinessql.global.infra.database.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "analysis")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Analysis extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "analysis_id")
+    private Long analysisId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "record_id")
+    private Record record;
+
+    @ElementCollection
+    @CollectionTable(name = "positive_sentiments", joinColumns = @JoinColumn(name = "analysis_id"))
+    @Column(name = "content")
+    private List<String> positiveSentiments = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "negative_sentiments", joinColumns = @JoinColumn(name = "analysis_id"))
+    @Column(name = "content")
+    private List<String> negativeSentiments = new ArrayList<>();
+
+    @Builder
+    public Analysis(Record record, List<String> positiveSentiments, List<String> negativeSentiments) {
+        this.record = record;
+        this.positiveSentiments = positiveSentiments;
+        this.negativeSentiments = negativeSentiments;
+    }
+
+
+
+}

--- a/src/main/java/com/hobak/happinessql/domain/record/domain/Record.java
+++ b/src/main/java/com/hobak/happinessql/domain/record/domain/Record.java
@@ -41,6 +41,9 @@ public class Record extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @OneToOne(mappedBy = "record", fetch = FetchType.LAZY)
+    private Analysis analysis;
+
     @Builder
     public Record(Integer happiness, String memo, User user, Activity activity) {
         this.happiness = happiness;

--- a/src/main/java/com/hobak/happinessql/domain/record/repository/AnalysisRepository.java
+++ b/src/main/java/com/hobak/happinessql/domain/record/repository/AnalysisRepository.java
@@ -1,0 +1,7 @@
+package com.hobak.happinessql.domain.record.repository;
+
+import com.hobak.happinessql.domain.record.domain.Analysis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,7 @@ cloud:
       auto: false
 jwt:
   secret: ${JWT_SECRET_KEY}
+
+sentiment:
+  clientId: ${NAVER_CLIENT_ID}
+  clientSecret: ${NAVER_CLIENT_SECRET}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Resolves #125

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

네이버 클라우드 CLOVA Sentiment를 추가했습니다. 
해당 API를 통해 사용자가 행복 기록 시, 메모를 입력했다면 메모를 기반으로 감정어 분석 기능을 추가했습니다. 
감정어 분석을 한 문장마다 진행되며, 긍정 또는 부정으로 판단된 문장만 저장되고 중립으로 판단된 문장은 저장되지 않습니다. 메모가 비어있다면 분석은 진행되지 않습니다. 

Analysis는 감정어 분석 결과를 저장하는 엔티티입니다. 이때 감정어 분석의 결과로 나온 긍정문/부정문은 각각 여러개의 문장이 저장되어야 하는 경우가 생깁니다. 즉, String(값 타입)을 컬렉션에 담아서 저장해야 합니다. 
하지만 기본적으로 관계형 데이터베이스에는 컬렉션을 저장할 수 없습니다. 따라서 컬렉션을 저장하기 위해서는 별도의 테이블을 만들어야 합니다. 
따라서 @ElementCollection을 사용했습니다.
@ElementCollection은 컬렉션 객체임을 JPA가 알 수 있게 해주며, 엔티티가 아닌 값 타입에 대한 테이블을 생성하고 1대다 관계로 다룹니다. 
@ElementCollection을 추가한 칼럼(positiveSentiments, negativeSentiments)은 주키로 Analysis 테이블의 주키(analysis_id) 값들을 가지는 테이블로 새로 생성됩니다. 이 테이블은 오직 부모 테이블(analysis)을 통해서만 접근이 가능합니다.

참고)
- analysis
<img width="669" alt="image" src="https://github.com/user-attachments/assets/dc27baa6-8085-491a-a966-b75b65098a17">

- negative_sentiments
<img width="350" alt="image" src="https://github.com/user-attachments/assets/93fa964e-5028-4092-9116-a6959c537efc">


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## ✅ Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성했는가?
- [x]  PR에 해당되는 Issue를 연결했는가?
- [x]  적절한 라벨을 설정했는가?
- [x]  작업한 사람을 모두 Assign했는가?
